### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
-#QGIS Resources
+# QGIS Resources
 
 This is a collection of QGIS symbols, styles, and scripts.
 
-##How to use
+## How to use
 
 Please use this download link to download the collection: https://github.com/anitagraser/QGIS-resources/zipball/master
 
 Of course you can also use Git. This way, you can easily update to the latest versions of all styles.
 
-##Contribute
+## Contribute
 
 Feel free to send pull requests if you want to add to this collection. 
 Until the QGIS project gets dedicated infrastructure for sharing symbols 

--- a/qgis1.8/styles/README.md
+++ b/qgis1.8/styles/README.md
@@ -1,8 +1,8 @@
-#QGIS Styles
+# QGIS Styles
 
 This is a collection of QGIS .qml and .sld styles. SLD is supported by QGIS >= 1.8
 
-##Contents
+## Contents
 
 * clc_2006_SLC_de.sld - Corine Land Cover - official colors (German labels)
 * corine_nice_de.qml - Corine Land Cover - nice colors (German)


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
